### PR TITLE
Align new appointment start slots

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This automatically sets **Microsoft Teams** presence to **"Busy"** — perfect a
 
 ## ✨ Features
 - 🗓️ **Start new focus blocks** (30/60/90/120 min) — F1–F4
+- ⏱️ **Aligned start times** — new blocks snap to configurable minute slots (default 00/15/30/45) and respect nearby bookings
 - ➕ **Extend the current appointment** (+30/+60/+90/+120 min) — F5–F8
 - 🔒 Appointments are ~~**private**~~ and categorized **"Tracking"**
 - 🖥️ **Dark-ish** WinForms dialog, DPI-aware, focus fix (AttachThreadInput)
@@ -54,9 +55,12 @@ powershell.exe -NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -File "C:\
 ## 🔧 Configuration (at the top of the script)
 - `$CategoryName = "Tracking"` (created automatically if missing)
 - `$DurationsStart / $DurationsExtend` — button minutes
+- `$AllowedStartMinutes` — minute marks for start alignment (e.g. `@(0,15,30,45)`); use `@()` to disable rounding
 - `$BtnWidth / $BtnHeight` — button sizes
 - Theme colors (dark/subtle) are defined as variables
 - Optional: `$SilentExtendDefault = $true` (disable MessageBox after "Extend")
+
+When alignment is active, the script checks for nearby appointments that just ended or are about to end and starts the new block right after them; otherwise it rounds to the closest allowed slot.
 
 ## 🧪 CLI Parameters (optional)
 ~~~powershell

--- a/README_de.md
+++ b/README_de.md
@@ -12,6 +12,7 @@ Dadurch setzt **Microsoft Teams** den Status automatisch auf **„Beschäftigt�
 
 ## ✨ Features
 - 🗓️ **Neue Fokus-Blöcke** starten (30/60/90/120 Min) – F1–F4
+- ⏱️ **Fixe Startzeiten** – neue Blöcke rasten auf konfigurierbare Minuten (Standard 00/15/30/45) ein und berücksichtigen angrenzende Termine
 - ➕ **Laufenden Termin fortsetzen** (+30/+60/+90/+120 Min) – F5–F8
 - 🔒 Termine sind ~~**privat**~~ und mit Kategorie **„Tracking“**
 - 🖥️ **Dark-ish** WinForms-Dialog, DPI-aware, Fokus-Fix (AttachThreadInput)
@@ -57,9 +58,12 @@ powershell.exe -NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -File "C:\
 ## 🔧 Konfiguration (im Script Kopfbereich)
 - `$CategoryName = "Tracking"` (wird bei Bedarf automatisch angelegt)
 - `$DurationsStart / $DurationsExtend` – Button-Minuten
+- `$AllowedStartMinutes` – Minutenmarken für den Start (z. B. `@(0,15,30,45)`); mit `@()` lässt sich die Rundung abschalten
 - `$BtnWidth / $BtnHeight` – Größe der Buttons
 - Theme-Farben (dunkel/dezent) sind als Variablen definiert
 - Optional: `$SilentExtendDefault = $true` (MessageBox nach „Extend“ abschalten)
+
+Mit aktivierter Ausrichtung sucht das Script nach Terminen, die gerade geendet haben oder in wenigen Minuten enden, und startet den neuen Block direkt danach; ansonsten wird auf den nächstgelegenen erlaubten Slot gerundet.
 
 ## 🧪 CLI-Parameter (optional)
 ~~~powershell


### PR DESCRIPTION
## Summary
- align newly created tracking appointments with configurable minute slots (default 00/15/30/45)
- consider nearby Outlook appointments ending within the next few minutes before choosing the start time
- document the start-slot configuration option in both English and German readme files and bump the script version to 1.2

## Testing
- not run (requires Outlook/Windows environment)


------
https://chatgpt.com/codex/tasks/task_e_68ca89d7fbf883248372802ede87483c