### PR TITLE
Expose CLI parameters and refresh documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,11 @@ When alignment is active, the script checks for nearby appointments that just en
 -Subject <string>        # Task/subject name
 -StartMinutes <int>      # Start a block immediately with this duration in minutes (skips GUI)
 -ExtendMinutes <int>     # Extend the currently running appointment
+-Private                 # Switch — mark the next block as private (also pre-checks the GUI)
 ~~~
+
+`-StartMinutes` and `-ExtendMinutes` are mutually exclusive; provide a positive value for exactly one of them. `-Subject` can be
+used on its own to pre-fill the GUI.
 
 ## FAQ
 

--- a/README_de.md
+++ b/README_de.md
@@ -5,7 +5,7 @@
 PowerShell-Tool mit GUI **und** CLI, das über Outlook private „Tracking“-Termine anlegt/verlängert.  
 Dadurch setzt **Microsoft Teams** den Status automatisch auf **„Beschäftigt“** - ideal als Stream-Deck-Action.
 
-![Track & Block - Screenshot](../assets/screenshot.png)
+![Track & Block — Screenshot](/assets/screenshot.png?raw=true)
 
 ## Features
 
@@ -61,7 +61,7 @@ powershell.exe -NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -File "C:\
 - `$CategoryName = "Tracking"` (wird bei Bedarf automatisch angelegt)
 - `$DurationsStart / $DurationsExtend` - Button-Minuten
 - `$AllowedStartMinutes` - Minutenmarken für den Start (z. B. `@(0,15,30,45)`); Zulässig sind Minuten 0-59; Duplikate werden ignoriert; mit `@()` lässt sich die Rundung abschalten
-- `$AlignmentLookAroundMinutes` — Zeitraum in Minuten zum suchen von angrenzenden Termin-Ende (Standard: 10)
+- `$AlignmentLookAroundMinutes` — Zeitraum in Minuten zum Suchen von angrenzenden Terminenden (Standard: 10)
 - `$BtnWidth / $BtnHeight` - Größe der Buttons
 - Theme-Farben (dunkel/dezent) sind als Variablen definiert
 - Optional: `$SilentExtendDefault = $true` (MessageBox nach „Extend“ abschalten)

--- a/README_de.md
+++ b/README_de.md
@@ -1,6 +1,6 @@
 # Outlook-TrackAndBlock
 
-[🇺🇸 Englische Version dieser Datei](/README_de.md)
+[🇺🇸 Englische Version dieser Datei](/README.md)
 
 PowerShell-Tool mit GUI **und** CLI, das über Outlook private „Tracking“-Termine anlegt/verlängert.  
 Dadurch setzt **Microsoft Teams** den Status automatisch auf **„Beschäftigt“** - ideal als Stream-Deck-Action.
@@ -74,7 +74,11 @@ Mit aktivierter Ausrichtung sucht das Script nach Terminen, die gerade geendet h
 -Subject <string>        # Betreff/Name der Aufgabe
 -StartMinutes <int>      # Startet sofort einen Block (GUI wird übersprungen)
 -ExtendMinutes <int>     # Verlängert den aktuell laufenden Termin
+-Private                 # Schalter – markiert den neuen Block als privat (GUI wird vorab angehakt)
 ~~~
+
+`-StartMinutes` und `-ExtendMinutes` lassen sich nicht kombinieren; gib genau einen positiven Minutenwert für eine der Option
+en an. `-Subject` kann auch allein genutzt werden, um die GUI vorab zu befüllen.
 
 ## FAQ
 

--- a/README_de.md
+++ b/README_de.md
@@ -77,9 +77,7 @@ Mit aktivierter Ausrichtung sucht das Script nach Terminen, die gerade geendet h
 -Private                 # Schalter – markiert den neuen Block als privat (GUI wird vorab angehakt)
 ~~~
 
-`-StartMinutes` und `-ExtendMinutes` lassen sich nicht kombinieren; gib genau einen positiven Minutenwert für eine der Option
-en an. `-Subject` kann auch allein genutzt werden, um die GUI vorab zu befüllen.
-
+`-StartMinutes` und `-ExtendMinutes` lassen sich nicht kombinieren; gib genau einen positiven Minutenwert für eine der Optionen an. `-Subject` kann auch allein genutzt werden, um die GUI vorab zu befüllen.
 ## FAQ
 
 **Setzt das Tool „Nicht stören (DND)“ in Teams?**  

--- a/scripts/Outlook_Timetracker.ps1
+++ b/scripts/Outlook_Timetracker.ps1
@@ -52,11 +52,10 @@ if (-not (Test-Path $AppDir)) { New-Item -ItemType Directory -Path $AppDir -Forc
 $StoredSubject = $null
 try {
     if (Test-Path $LastSubjectFile) {
-        $StoredSubject = Get-Content $LastSubjectFile -EA SilentlyContinue | Select-Object -First 1
+        $StoredSubject = Get-Content $LastSubjectFile -Encoding UTF8 -EA SilentlyContinue | Select-Object -First 1
     }
 } catch {}
 if ($StoredSubject -ne $null) { $StoredSubject = $StoredSubject.Trim() }
-
 $normalizedSlots = [System.Collections.Generic.List[int]]::new()
 foreach ($slot in $AllowedStartMinutes) {
     $parsed = 0

--- a/scripts/Outlook_Timetracker.ps1
+++ b/scripts/Outlook_Timetracker.ps1
@@ -1,6 +1,8 @@
 param(
     [string]$Subject,
+    [ValidateRange(1, 1440)]
     [int]$StartMinutes,
+    [ValidateRange(1, 1440)]
     [int]$ExtendMinutes,
     [switch]$Private
 )
@@ -384,6 +386,8 @@ $cliExtendRequested = $PSBoundParameters.ContainsKey('ExtendMinutes')
 if ($cliStartRequested -and $cliExtendRequested) {
     [System.Windows.Forms.MessageBox]::Show("Use -StartMinutes or -ExtendMinutes, not both.","Invalid parameters",
         [System.Windows.Forms.MessageBoxButtons]::OK,[System.Windows.Forms.MessageBoxIcon]::Warning) | Out-Null
+    Write-Error "Use -StartMinutes or -ExtendMinutes, not both."
+    $global:LASTEXITCODE = 1
     return
 }
 
@@ -391,6 +395,8 @@ if ($cliStartRequested) {
     if ($StartMinutes -le 0) {
         [System.Windows.Forms.MessageBox]::Show("StartMinutes must be a positive number of minutes.","Invalid StartMinutes",
             [System.Windows.Forms.MessageBoxButtons]::OK,[System.Windows.Forms.MessageBoxIcon]::Warning) | Out-Null
+        Write-Error "StartMinutes must be a positive integer."
+        $global:LASTEXITCODE = 1
         return
     }
 
@@ -403,6 +409,8 @@ if ($cliExtendRequested) {
     if ($ExtendMinutes -le 0) {
         [System.Windows.Forms.MessageBox]::Show("ExtendMinutes must be a positive number of minutes.","Invalid ExtendMinutes",
             [System.Windows.Forms.MessageBoxButtons]::OK,[System.Windows.Forms.MessageBoxIcon]::Warning) | Out-Null
+        Write-Error "ExtendMinutes must be a positive integer."
+        $global:LASTEXITCODE = 1
         return
     }
 
@@ -520,7 +528,7 @@ $extendButtons=@()
 for ($i=0; $i -lt $DurationsExtend.Count; $i++) {
     $mins=$DurationsExtend[$i]
     $btn = New-NiceButton "＋  +$mins min  (F$($i+5))" $mins $ClrPlus $ClrBg (Lighten $ClrPlus 18)
-    $btn.Add_Click([System.EventHandler]{ param($sender,$e) Extend-CurrentAppointment -AddMinutes ([int]$sender.Tag) })
+    $btn.Add_Click([System.EventHandler]{ param($sender,$e) Extend-CurrentAppointment -AddMinutes ([int]$sender.Tag) -Silent:$SilentExtendDefault })
     $tt.SetToolTip($btn, "Extend current appointment by $mins minutes")
     $panelExtend.Controls.Add($btn) | Out-Null
     $extendButtons += $btn


### PR DESCRIPTION
## Summary
- expose the documented CLI parameters for starting or extending appointments directly from the script
- persist subject/private defaults for CLI usage and add validation around mutually exclusive options
- document the new CLI behavior in both the English and German READMEs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added -Private flag to mark new appointments as private; GUI pre-checks it.
  * Direct CLI actions: use -StartMinutes or -ExtendMinutes (mutually exclusive, must be positive) to start or extend blocks; CLI rejects combining them.
  * Subject persistence: last subject remembered and GUI pre-filled; -Subject can pre-fill via CLI.
  * Added option to suppress post-extend pop-up (SilentExtendDefault).

* **Documentation**
  * Clarified CLI parameter rules and subject prefill behavior.
  * Updated DND note (Outlook “Busy” vs. true Teams DND) and US date format; fixed German README link.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->